### PR TITLE
Fixes and Improvements – Part 2

### DIFF
--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
@@ -227,32 +227,32 @@ namespace Cocodrilo.ElementProperties
             Analyses.Analysis Analysis,
             string ModelPartName)
         {
-            if (ThisOutputOptions.conditions)
-            {
-                var integration_point_results = new List<string> { "PENALTY_REACTION_FORCE" };
-                string[] nodal_results = new string[] { };
+            //if (ThisOutputOptions.conditions)
+            //{
+            //     var integration_point_results = new List<string> { "PENALTY_REACTION_FORCE" };
+            //     string[] nodal_results = new string[] { };
 
-                var output_process_parameters = new Dictionary<string, object>
-                {
-                    { "nodal_results", nodal_results },
-                    { "integration_point_results", integration_point_results},
-                    { "output_file_name", Analysis.Name + "_kratos_coupling_" + mPropertyId + ".post.res"},
-                    { "model_part_name", ModelPartName + "." + GetKratosModelPart() },
-                    { "file_label", "step" },
-                    { "output_control_type", "time" },
-                    { "output_frequency", CocodriloPlugIn.Instance.OutputOptions.output_frequency }
-                };
-                return new Dictionary<string, object>
-                {
-                    { "kratos_module", "IgaApplication"},
-                    { "python_module", "iga_output_process"},
-                    { "Parameters", output_process_parameters}
-                };
-            }
-            else
-            {
+            //     var output_process_parameters = new Dictionary<string, object>
+            //     {
+            //         { "nodal_results", nodal_results },
+            //         { "integration_point_results", integration_point_results},
+            //         { "output_file_name", Analysis.Name + "_kratos_coupling_" + mPropertyId + ".post.res"},
+            //         { "model_part_name", ModelPartName + "." + GetKratosModelPart() },
+            //         { "file_label", "step" },
+            //         { "output_control_type", "time" },
+            //         { "output_frequency", CocodriloPlugIn.Instance.OutputOptions.output_frequency }
+            //     };
+            //     return new Dictionary<string, object>
+            //     {
+            //         { "kratos_module", "IgaApplication"},
+            //         { "python_module", "iga_output_process"},
+            //         { "Parameters", output_process_parameters}
+            //     };
+            // }
+            // else
+            // {
                 return new Dictionary<string, object>();
-            }
+            //}
         }
     }
 }

--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
@@ -60,7 +60,6 @@ namespace Cocodrilo.ElementProperties
 
             var parameters_displacements = new Dictionary<string, object>
             {
-                {"mesh_id", 0},
                 {"model_part_name", "IgaModelPart." + GetKratosModelPart()},
                 {"variable_name", "DISPLACEMENT"},
                 {"value", displacements},
@@ -86,7 +85,6 @@ namespace Cocodrilo.ElementProperties
                 var rotations = new object[] { 0.0, 0.0, 0.0 };
                 var parameters_rotations = new Dictionary<string, object>
                 {
-                    {"mesh_id", 0},
                     {"model_part_name", "IgaModelPart." + GetKratosModelPart()},
                     {"variable_name", "ROTATION"},
                     {"value", rotations},

--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertyCoupling.cs
@@ -70,7 +70,9 @@ namespace Cocodrilo.ElementProperties
             {
             };
 
-            if (GetCouplingType() == CouplingType.CouplingPenaltyCondition)
+            if (GetCouplingType() == CouplingType.CouplingPenaltyCondition || 
+                GetCouplingType() == CouplingType.CouplingLagrangeCondition ||
+                GetCouplingType() == CouplingType.CouplingNitscheCondition)
             {
                 processes_list.Add(new Dictionary<string, object>
                 {

--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertyLoad.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertyLoad.cs
@@ -106,7 +106,6 @@ namespace Cocodrilo.ElementProperties
             
             var parameters = new Dictionary<string, object>
             {
-                {"mesh_id", 0 },
                 {"model_part_name", "IgaModelPart." + GetKratosModelPart() },
                 {"variable_name", variable_name },
                 {"value", value },

--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertySupport.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertySupport.cs
@@ -97,7 +97,6 @@ namespace Cocodrilo.ElementProperties
             {
                 var parameters = new Dictionary<string, object>
                 {
-                    {"mesh_id", 0 },
                     {"model_part_name", "IgaModelPart." + GetKratosModelPart() },
                     {"variable_name", "DISPLACEMENT" },
                     {"value", supports },
@@ -115,7 +114,6 @@ namespace Cocodrilo.ElementProperties
                 {
                     var parameters_rotation = new Dictionary<string, object>
                     {
-                        {"mesh_id", 0 },
                         {"model_part_name", "IgaModelPart." + GetKratosModelPart()  },
                         {"variable_name", "ROTATION" },
                         {"value", supports },
@@ -159,7 +157,6 @@ namespace Cocodrilo.ElementProperties
             {
                 var parameters = new Dictionary<string, object>
                 {
-                    {"mesh_id", 0 },
                     {"model_part_name", "IgaModelPart." + GetKratosModelPart() },
                     {"variable_name", "DISPLACEMENT" },
                     {"value", supports },
@@ -187,7 +184,6 @@ namespace Cocodrilo.ElementProperties
 
                     var parameters_rotation = new Dictionary<string, object>
                     {
-                        {"mesh_id", 0 },
                         {"model_part_name", model_part_name },
                         {"variable_name", variable_name },
                         {"value", supports },

--- a/Cocodrilo/Cocodrilo/ElementProperties/PropertySupport.cs
+++ b/Cocodrilo/Cocodrilo/ElementProperties/PropertySupport.cs
@@ -57,8 +57,8 @@ namespace Cocodrilo.ElementProperties
             var condition_variable_list = new List<string>();
             if (mSupport.mIsSupportStrong == true)
                 condition_variable_list.Add("REACTION");
-            else if (mSupport.mSupportType == "SupportPenaltyCondition")
-                condition_variable_list.Add("PENALTY_REACTION_FORCE");
+            // else if (mSupport.mSupportType == "SupportPenaltyCondition")
+            //     condition_variable_list.Add("PENALTY_REACTION_FORCE");
             else if (mSupport.mSupportType == "SupportLagrangeCondition")
                 condition_variable_list.Add("VECTOR_LAGRANGE_MULTIPLIER");
 


### PR DESCRIPTION
This PR addresses a few issues to improve functionality related to coupling multiple patches:

-Remove `mesh_id` (Kratos depreceated)
-Remove temporaily the `PENALTY_REACTION_FORCE ` from the output (to be added later)
-Fix bug with Nitsche and LM output

FYI:
@juancamarotti 